### PR TITLE
Update run.md to follow what seems to actually work

### DIFF
--- a/main/templates/tutorial/run.md
+++ b/main/templates/tutorial/run.md
@@ -1,11 +1,13 @@
 We assume that you already know how to run the Google App Engine
 applications from a command line, but if not you should refer to the
 [documentation](https://developers.google.com/appengine/docs/python/gettingstartedpython27/helloworld).
-Execute in your terminal the `run.py` from the root directory
+
+Since gae-init uses Gulp to build assets and bower to manage JavaScript libraries, you'll need to run
+bower to get started:
 
 ```bash
-$ cd /path/to/phonebook
-$ ./run.py -s
+npm install
+gulp
 ```
 
 If everything went smoothly you can test the application by visiting the


### PR DESCRIPTION
If you just follow the docs as-is, you don't see any bootstrap assets. They just generate 404's. This seems to work, and it's what's recommended in the readme file.